### PR TITLE
chore: pin dependencies to immutable SHAs via ghat

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,7 @@ repos:
     hooks:
       - id: markdownlint
   - repo: https://github.com/jameswoolfenden/pre-commit
-    rev: ba5c36a3150a4184f9ee362a5cf11611ee9ae185 # v0.1.52
+    rev: e022e4ac6ed682e95d1e813ee62d4fece371014b # v0.1.53
     hooks:
       - id: terraform-fmt
       - id: tf2docs

--- a/example/examplea/module.rds.tf
+++ b/example/examplea/module.rds.tf
@@ -13,5 +13,5 @@ module "rds" {
   vpc_id                  = "vpc-03036aea287d9ee9b"
 }
 module "data" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=5769331633debca683a81a38470083a0abd39049"
+  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }

--- a/example/examplea/terraform.tf
+++ b/example/examplea/terraform.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "4.62.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
     random = {
-      version = "3.4.3"
       source  = "hashicorp/random"
+      version = "3.8.1"
     }
   }
   required_version = ">=1.3.0"

--- a/example/examplemssql/module.rds-mssql.tf
+++ b/example/examplemssql/module.rds-mssql.tf
@@ -12,5 +12,5 @@ module "rds-mssql" {
   vpc_id            = data.aws_vpc.examplea[0].id
 }
 module "data" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=5769331633debca683a81a38470083a0abd39049"
+  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }

--- a/example/examplemssql/terraform.tf
+++ b/example/examplemssql/terraform.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     aws = {
-      version = "4.6.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
   }
   required_version = ">=0.14.8"

--- a/example/examplepostgres/module.rds.tf
+++ b/example/examplepostgres/module.rds.tf
@@ -28,5 +28,5 @@ data "aws_vpc" "examplea" {
   id    = tolist(data.aws_vpcs.examplea.ids)[count.index]
 }
 module "data" {
-  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=5769331633debca683a81a38470083a0abd39049"
+  source = "git::https://github.com/JamesWoolfenden/terraform-http-ip.git?ref=2f3cef24e667fb840a3d3481f5a1aaa5a1ac7d28" #v0.3.14
 }

--- a/example/examplepostgres/terraform.tf
+++ b/example/examplepostgres/terraform.tf
@@ -1,12 +1,12 @@
 terraform {
   required_providers {
     aws = {
-      version = "4.6.0"
       source  = "hashicorp/aws"
+      version = "6.43.0"
     }
     random = {
-      version = "3.0.0"
       source  = "hashicorp/random"
+      version = "3.8.1"
     }
   }
   required_version = ">=0.14.8"


### PR DESCRIPTION
Automated dependency pinning by [ghat](https://github.com/JamesWoolfenden/ghat).

Pins GitHub Actions, pre-commit hooks, Terraform modules/providers, Dockerfiles, and Kubernetes images to SHA digests.